### PR TITLE
Executable files for programs should be owned by root.

### DIFF
--- a/build.py
+++ b/build.py
@@ -46,7 +46,7 @@ def docker_build_packages(dockcross_exec):
     Returns:
         bool: True if the command completed successfully, False if it didn't.
     """
-    cmd = [f"./{dockcross_exec} bash -c 'cd build_packages && python3.6 build_packages.py -t build-temp -o output -c $CC -p $CXX -s $STRIP -x armv7-unknown-linux-gnueabihf'"]
+    cmd = [f"./{dockcross_exec} bash -c 'cd build_packages && sudo python3.6 build_packages.py -t build-temp -o output -c $CC -p $CXX -s $STRIP -x armv7-unknown-linux-gnueabihf'"]
     print(f"command: {cmd}")
     build = subprocess.Popen(cmd, shell=True)
     exit_code = build.wait()

--- a/build_packages/build_packages.py
+++ b/build_packages/build_packages.py
@@ -77,6 +77,8 @@ def build(temp_dir, build_dir, c_compiler=None, cpp_compiler=None, strip_bin=Non
     build_success["find_tags"] = find_tags.build(temp_dir, build_dir, find_tags_version, cpp_compiler, strip_bin, xcc_host)
 
     if all(build_success.values()):
+        print(f"[{timestamp()}]: Cleaning up temporary build files.")
+        rmtree(temp_dir)
         print(f"[{timestamp()}]: {bcolors.GREEN}Sensorgnome software packages successfully built.{bcolors.ENDC}")
         return True
     else:


### PR DESCRIPTION
Also added a cleanup of temporary files, because they're owned by root,
and it's annoying to run the whole build script as root, even if it is
in the dockcross container.